### PR TITLE
Switch from Codecov to Coveralls for coverage reporting

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: github-actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,7 @@ jobs:
       - run: yarn
       - run: yarn lint
       - run: yarn test
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate and Validate HKID
 
 [![npm version](https://badge.fury.io/js/hkid.svg)](https://badge.fury.io/js/hkid)
 [![Node.js CI](https://github.com/tsekityam/hkid/actions/workflows/test.yml/badge.svg)](https://github.com/tsekityam/hkid/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/tsekityam/hkid/branch/main/graph/badge.svg?token=34ZuXbF3md)](https://codecov.io/gh/tsekityam/hkid)
+[![Coverage Status](https://coveralls.io/repos/github/tsekityam/hkid/badge.svg?branch=main)](https://coveralls.io/github/tsekityam/hkid?branch=main)
 [![Known Vulnerabilities](https://snyk.io/test/github/tsekityam/hkid/badge.svg)](https://snyk.io/test/github/tsekityam/hkid)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftsekityam%2Fhkid.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftsekityam%2Fhkid?ref=badge_shield)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/rewire": "^2.5.28",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
-    "codecov": "^3.8.3",
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -32,7 +31,7 @@
     "lint": "eslint --ignore-path '.gitignore' '**/*.ts'",
     "format": "prettier --ignore-unknown --ignore-path '.gitignore' --write '**/*'",
     "test": "nyc mocha",
-    "posttest": "nyc report --reporter=text-lcov | codecov --pipe"
+    "posttest": "mkdir -p coverage && nyc report --reporter=text-lcov > coverage/test.lcov"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Replaces Codecov with Coveralls in CI workflow and README badge. Adds .coveralls.yml configuration, updates the GitHub Actions workflow to use the Coveralls action, and removes the codecov dependency and related posttest script from package.json.