### PR TITLE
Remove yarn cache configuration in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
       - run: yarn
       - run: yarn lint
       - run: yarn test


### PR DESCRIPTION
Eliminate the cache configuration for yarn in the continuous integration workflow to streamline the process.